### PR TITLE
test: Update embedding vector dimensions in tests

### DIFF
--- a/tests/backend/data_processing/test_sample_data.py
+++ b/tests/backend/data_processing/test_sample_data.py
@@ -145,7 +145,8 @@ def get_sample_embeddings(section_ids: list[str]) -> list[SectionEmbedding]:
     
     for i, section_id in enumerate(section_ids):
         # Create a unique vector for each section based on its index
-        vector = [float(i + j)/1000 for j in range(384)]
+        # Note: Vector length is now 768 to match the schema used in production
+        vector = [float(i + j)/1000 for j in range(768)]
         embeddings.append({
             "section_id": section_id,
             "embedding": vector


### PR DESCRIPTION
## Summary
- Updates the test_sample_data.py to generate 768-dimensional embedding vectors
- Aligns test data with the new schema introduced in PR #6
- Ensures all tests pass with the updated database schema

## Details
After merging PR #6 which updated the section_embeddings table schema to use 768-dimensional vectors, the tests were failing due to a dimension mismatch. This PR updates the test data generation to use the correct vector size.

## Test Results
All 84 tests now pass successfully.